### PR TITLE
Check if drawable is inside the viewport when drawing

### DIFF
--- a/src/Drawable.js
+++ b/src/Drawable.js
@@ -202,6 +202,51 @@ class Drawable {
     }
 
     /**
+     * If rotationCenterDirty or skinScaleDirty is dirty
+     * then set _calculateTransform first
+     * because _rotationAdjusted and _skinScale
+     * needs to call _calculateTransform before using
+     * @returns {boolean} transform before check the viewport
+     */
+    transformBeforeCheckViewport () {
+        return this._rotationCenterDirty || this._skinScaleDirty;
+    }
+    /**
+     * cheak drawable is in viewport
+     * @param {number} halfNativeSizeX viewport wdith
+     * @param {number} halfNativeSizeY viewport height
+     * @returns {boolean} Is it in viewport
+     */
+    inViewport (halfNativeSizeX, halfNativeSizeY) {
+        // position of this texture
+        const positionX = ~~(this._position[0] + 0.5 - this._rotationAdjusted[0]);
+        const positionY = ~~(this._position[1] + 0.5 - this._rotationAdjusted[1]);
+        // Half the size
+        const halfSizeX = ~~((this._skinScale[0] / 2) + 0.5);
+        const halfSizeY = ~~((this._skinScale[1] / 2) + 0.5);
+
+        // The leftTop and rightBottomX of the sprite must be enlarged,
+        // otherwise there will be problems when rotating
+        const maxHalfSize = Math.max(halfSizeX, halfSizeY);
+
+        const leftTopX = positionX - halfSizeX - maxHalfSize;
+        // Y-axis is reversed
+        const leftTopY = positionY + halfSizeY + maxHalfSize;
+
+        const rightBottomX = positionX + halfSizeX + maxHalfSize;
+        // Y-axis is reversed
+        const rightBottomY = positionY - halfSizeY - maxHalfSize;
+
+        if (rightBottomX < -halfNativeSizeX || rightBottomY > halfNativeSizeY) {
+            return false;
+        }
+        if (leftTopX > halfNativeSizeX || leftTopY < -halfNativeSizeY) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
      * Update the position if it is different. Marks the transform as dirty.
      * @param {Array.<number>} position A new position.
      */

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -2076,7 +2076,7 @@ class RenderWebGL extends EventEmitter {
             const drawable = this._allDrawables[drawableID];
 
             const uniforms = {};
-            if (drawMode === 'default' && drawable.skin) {
+            if (drawMode === ShaderManager.DRAW_MODE.default && drawable.skin) {
                 // If rotationCenterDirty or skinScaleDirty is dirty, then set _calculateTransform first
                 // because _rotationAdjusted and _skinScale  needs to call _calculateTransform before using
                 let uniformHasBeenSet = false

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -2058,8 +2058,8 @@ class RenderWebGL extends EventEmitter {
         const gl = this._gl;
         let currentShader = null;
 
-        const halfNativeSizeX = this._nativeSize[0] / 2
-        const halfNativeSizeY = this._nativeSize[1] / 2
+        const halfNativeSizeX = this._nativeSize[0] / 2;
+        const halfNativeSizeY = this._nativeSize[1] / 2;
 
         const framebufferSpaceScaleDiffers = (
             'framebufferWidth' in opts && 'framebufferHeight' in opts &&
@@ -2093,7 +2093,8 @@ class RenderWebGL extends EventEmitter {
                 const halfSizeX = ~~((drawable._skinScale[0] / 2) + 0.5);
                 const halfSizeY = ~~((drawable._skinScale[1] / 2) + 0.5);
 
-                // The leftTop and rightBottomX of the sprite must be enlarged, otherwise there will be problems when rotating
+                // The leftTop and rightBottomX of the sprite must be enlarged,
+                // otherwise there will be problems when rotating
                 const maxHalfSize = Math.max(halfSizeX, halfSizeY);
 
                 const leftTopX = positionX - halfSizeX - maxHalfSize;

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -2085,7 +2085,7 @@ class RenderWebGL extends EventEmitter {
                     uniformHasBeenSet = true;
                 }
 
-                if (drawable.inViewport(halfNativeSizeX, halfNativeSizeY)) continue;
+                if (!drawable.inViewport(halfNativeSizeX, halfNativeSizeY)) continue;
                 if (!uniformHasBeenSet) {
                     // If unconfirm was not set before
                     Object.assign(uniforms, drawable.getUniforms());

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -2080,37 +2080,12 @@ class RenderWebGL extends EventEmitter {
                 // If rotationCenterDirty or skinScaleDirty is dirty, then set _calculateTransform first
                 // because _rotationAdjusted and _skinScale  needs to call _calculateTransform before using
                 let uniformHasBeenSet = false;
-                if (drawable._rotationCenterDirty || drawable._skinScaleDirty) {
+                if (drawable.transformBeforeCheckViewport()) {
                     Object.assign(uniforms, drawable.getUniforms());
                     uniformHasBeenSet = true;
                 }
 
-                const drawablePosition = drawable._position;
-                // position of this texture
-                const positionX = ~~(drawablePosition[0] + 0.5 - drawable._rotationAdjusted[0]);
-                const positionY = ~~(drawablePosition[1] + 0.5 - drawable._rotationAdjusted[1]);
-                // Half the size
-                const halfSizeX = ~~((drawable._skinScale[0] / 2) + 0.5);
-                const halfSizeY = ~~((drawable._skinScale[1] / 2) + 0.5);
-
-                // The leftTop and rightBottomX of the sprite must be enlarged,
-                // otherwise there will be problems when rotating
-                const maxHalfSize = Math.max(halfSizeX, halfSizeY);
-
-                const leftTopX = positionX - halfSizeX - maxHalfSize;
-                // Y-axis is reversed
-                const leftTopY = positionY + halfSizeY + maxHalfSize;
-
-                const rightBottomX = positionX + halfSizeX + maxHalfSize;
-                // Y-axis is reversed
-                const rightBottomY = positionY - halfSizeY - maxHalfSize;
-
-                if (rightBottomX < -halfNativeSizeX || rightBottomY > halfNativeSizeY) {
-                    continue;
-                }
-                if (leftTopX > halfNativeSizeX || leftTopY < -halfNativeSizeY) {
-                    continue;
-                }
+                if (drawable.inViewport(halfNativeSizeX, halfNativeSizeY)) continue;
                 if (!uniformHasBeenSet) {
                     // If unconfirm was not set before
                     Object.assign(uniforms, drawable.getUniforms());

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -2058,6 +2058,9 @@ class RenderWebGL extends EventEmitter {
         const gl = this._gl;
         let currentShader = null;
 
+        const halfNativeSizeX = this._nativeSize[0] / 2
+        const halfNativeSizeY = this._nativeSize[1] / 2
+
         const framebufferSpaceScaleDiffers = (
             'framebufferWidth' in opts && 'framebufferHeight' in opts &&
             opts.framebufferWidth !== this._nativeSize[0] && opts.framebufferHeight !== this._nativeSize[1]
@@ -2071,7 +2074,49 @@ class RenderWebGL extends EventEmitter {
             if (opts.filter && !opts.filter(drawableID)) continue;
 
             const drawable = this._allDrawables[drawableID];
-            /** @todo check if drawable is inside the viewport before anything else */
+
+            const uniforms = {};
+            if (drawMode === 'default' && drawable.skin) {
+                // If rotationCenterDirty or skinScaleDirty is dirty, then set _calculateTransform first
+                // because _rotationAdjusted and _skinScale  needs to call _calculateTransform before using
+                let uniformHasBeenSet = false
+                if (drawable._rotationCenterDirty || drawable._skinScaleDirty) {
+                    Object.assign(uniforms, drawable.getUniforms())
+                    uniformHasBeenSet = true
+                }
+
+                const drawablePosition = drawable._position
+                // position of this texture
+                const positionX = ~~(drawablePosition[0] + 0.5 - drawable._rotationAdjusted[0])
+                const positionY = ~~(drawablePosition[1] + 0.5 - drawable._rotationAdjusted[1])
+                // Half the size
+                const halfSizeX = ~~(drawable._skinScale[0] / 2 + 0.5)
+                const halfSizeY = ~~(drawable._skinScale[1] / 2 + 0.5)
+
+                // The leftTop and rightBottomX of the sprite must be enlarged, otherwise there will be problems when rotating
+                const maxHalfSize = Math.max(halfSizeX, halfSizeY)
+
+                const leftTopX = positionX - halfSizeX - maxHalfSize
+                // Y-axis is reversed
+                const leftTopY = positionY + halfSizeY + maxHalfSize 
+
+                const rightBottomX = positionX + halfSizeX + maxHalfSize
+                // Y-axis is reversed
+                const rightBottomY = positionY - halfSizeY - maxHalfSize 
+
+                if (rightBottomX < -halfNativeSizeX || rightBottomY > halfNativeSizeY) {
+                    continue
+                }
+                if (leftTopX > halfNativeSizeX || leftTopY < -halfNativeSizeY) {
+                    continue
+                }
+                if (!uniformHasBeenSet) {
+                    // If unconfirm was not set before
+                    Object.assign(uniforms, drawable.getUniforms())
+                }
+            } else {
+                Object.assign(uniforms, drawable.getUniforms())
+            }
 
             // Hidden drawables (e.g., by a "hide" block) are not drawn unless
             // the ignoreVisibility flag is used (e.g. for stamping or touchingColor).
@@ -2091,7 +2136,6 @@ class RenderWebGL extends EventEmitter {
             // Skip private skins, if requested.
             if (opts.skipPrivateSkins && drawable.skin.private) continue;
 
-            const uniforms = {};
 
             let effectBits = drawable.enabledEffects;
             effectBits &= Object.prototype.hasOwnProperty.call(opts, 'effectMask') ? opts.effectMask : effectBits;
@@ -2112,8 +2156,7 @@ class RenderWebGL extends EventEmitter {
             }
 
             Object.assign(uniforms,
-                drawable.skin.getUniforms(drawableScale),
-                drawable.getUniforms());
+                drawable.skin.getUniforms(drawableScale));
 
             // Apply extra uniforms after the Drawable's, to allow overwriting.
             if (opts.extraUniforms) {

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -2079,43 +2079,43 @@ class RenderWebGL extends EventEmitter {
             if (drawMode === ShaderManager.DRAW_MODE.default && drawable.skin) {
                 // If rotationCenterDirty or skinScaleDirty is dirty, then set _calculateTransform first
                 // because _rotationAdjusted and _skinScale  needs to call _calculateTransform before using
-                let uniformHasBeenSet = false
+                let uniformHasBeenSet = false;
                 if (drawable._rotationCenterDirty || drawable._skinScaleDirty) {
-                    Object.assign(uniforms, drawable.getUniforms())
-                    uniformHasBeenSet = true
+                    Object.assign(uniforms, drawable.getUniforms());
+                    uniformHasBeenSet = true;
                 }
 
-                const drawablePosition = drawable._position
+                const drawablePosition = drawable._position;
                 // position of this texture
-                const positionX = ~~(drawablePosition[0] + 0.5 - drawable._rotationAdjusted[0])
-                const positionY = ~~(drawablePosition[1] + 0.5 - drawable._rotationAdjusted[1])
+                const positionX = ~~(drawablePosition[0] + 0.5 - drawable._rotationAdjusted[0]);
+                const positionY = ~~(drawablePosition[1] + 0.5 - drawable._rotationAdjusted[1]);
                 // Half the size
-                const halfSizeX = ~~(drawable._skinScale[0] / 2 + 0.5)
-                const halfSizeY = ~~(drawable._skinScale[1] / 2 + 0.5)
+                const halfSizeX = ~~((drawable._skinScale[0] / 2) + 0.5);
+                const halfSizeY = ~~((drawable._skinScale[1] / 2) + 0.5);
 
                 // The leftTop and rightBottomX of the sprite must be enlarged, otherwise there will be problems when rotating
-                const maxHalfSize = Math.max(halfSizeX, halfSizeY)
+                const maxHalfSize = Math.max(halfSizeX, halfSizeY);
 
-                const leftTopX = positionX - halfSizeX - maxHalfSize
+                const leftTopX = positionX - halfSizeX - maxHalfSize;
                 // Y-axis is reversed
-                const leftTopY = positionY + halfSizeY + maxHalfSize 
+                const leftTopY = positionY + halfSizeY + maxHalfSize;
 
-                const rightBottomX = positionX + halfSizeX + maxHalfSize
+                const rightBottomX = positionX + halfSizeX + maxHalfSize;
                 // Y-axis is reversed
-                const rightBottomY = positionY - halfSizeY - maxHalfSize 
+                const rightBottomY = positionY - halfSizeY - maxHalfSize;
 
                 if (rightBottomX < -halfNativeSizeX || rightBottomY > halfNativeSizeY) {
-                    continue
+                    continue;
                 }
                 if (leftTopX > halfNativeSizeX || leftTopY < -halfNativeSizeY) {
-                    continue
+                    continue;
                 }
                 if (!uniformHasBeenSet) {
                     // If unconfirm was not set before
-                    Object.assign(uniforms, drawable.getUniforms())
+                    Object.assign(uniforms, drawable.getUniforms());
                 }
             } else {
-                Object.assign(uniforms, drawable.getUniforms())
+                Object.assign(uniforms, drawable.getUniforms());
             }
 
             // Hidden drawables (e.g., by a "hide" block) are not drawn unless


### PR DESCRIPTION
### Proposed Changes

This PR adds support for not rendering sprites outside of the viewport.

### Reason for Changes

Currently, when rendering sprites, all of them are rendered regardless of whether they are within the viewport or not. This can lead to unnecessary performance overhead, especially when dealing with a large number of sprites. By implementing the feature to not render sprites outside of the viewport, we can significantly improve the rendering performance and optimize resource usage.


(all clones outside the screen)

![BFI{$~D0IH GPW{Z%SXNQ1J](https://github.com/TurboWarp/scratch-render/assets/149653910/4b467ae0-4424-4546-b8a6-9c8128ab6c76)

![YRX 7XQ W%5ZSXRV1C6H(SL](https://github.com/TurboWarp/scratch-render/assets/149653910/b48f704b-6bf7-44b0-a54d-5d52a775b9bd)
