### PR TITLE
Change webgl preference to webgl2

### DIFF
--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -123,9 +123,9 @@ class RenderWebGL extends EventEmitter {
             optCanvas = optCanvas || document.createElement('canvas');
             const options = {alpha: false, stencil: true, antialias: false};
             return !!(
-                optCanvas.getContext('webgl', options) ||
+                optCanvas.getContext('webgl2', options) ||
                 optCanvas.getContext('experimental-webgl', options) ||
-                optCanvas.getContext('webgl2', options)
+                optCanvas.getContext('webgl', options)
             );
         } catch (e) {
             return false;
@@ -147,9 +147,9 @@ class RenderWebGL extends EventEmitter {
         };
         // getWebGLContext = try WebGL 1.0 only
         // getContext = try WebGL 2.0 and if that doesn't work, try WebGL 1.0
-        // getWebGLContext || getContext = try WebGL 1.0 and if that doesn't work, try WebGL 2.0
-        return twgl.getWebGLContext(canvas, contextAttribs) ||
-            twgl.getContext(canvas, contextAttribs);
+        // getContext || getWebGLContext = try WebGL 2.0 and if that doesn't work, try WebGL 1.0
+        return twgl.getContext(canvas, contextAttribs) ||
+            twgl.getWebGLContext(canvas, contextAttribs);
     }
 
     /**


### PR DESCRIPTION
Changes the renderer webgl preference to try webgl2 first instead of webgl.

This allows for extensions like Pen+ to have greater capabilities, such as GLSL 3.0

Shouldn't break anything.