### PR TITLE
Optimize pen line drawing using instanced rendering

### DIFF
--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -128,8 +128,6 @@ class PenSkin extends Skin {
                 1, 0,
                 0, 0,
                 1, 1,
-                1, 1,
-                0, 0,
                 0, 1
             ]), gl.STATIC_DRAW);
         } else {
@@ -439,8 +437,8 @@ class PenSkin extends Skin {
             this.glVertexAttribDivisor(this.a_penPoints_loc, 1);
 
             this.glDrawArraysInstanced(
-                gl.TRIANGLES,
-                0, 6,
+                gl.TRIANGLE_STRIP,
+                0, 4,
                 this.attribute_index / PEN_ATTRIBUTE_STRIDE
             );
 

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -110,7 +110,7 @@ class PenSkin extends Skin {
 
         if (!gl.drawArraysInstanced) {
             // Fallback to ANGLE_instanced_arrays
-            this.instanced_arrays_ext = gl.getExtension("ANGLE_instanced_arrays");
+            this.instanced_arrays_ext = gl.getExtension('ANGLE_instanced_arrays');
         }
 
         this.onNativeSizeChanged = this.onNativeSizeChanged.bind(this);
@@ -404,7 +404,11 @@ class PenSkin extends Skin {
             this.instanced_arrays_ext.vertexAttribDivisorANGLE(this.a_lineThicknessAndLength_loc, 1);
             this.instanced_arrays_ext.vertexAttribDivisorANGLE(this.a_penPoints_loc, 1);
 
-            this.instanced_arrays_ext.drawArraysInstancedANGLE(gl.TRIANGLES, 0, 6, this.attribute_index / PEN_ATTRIBUTE_STRIDE);
+            this.instanced_arrays_ext.drawArraysInstancedANGLE(
+                gl.TRIANGLES,
+                0, 6,
+                this.attribute_index / PEN_ATTRIBUTE_STRIDE
+            );
 
             this.instanced_arrays_ext.vertexAttribDivisorANGLE(this.a_lineColor_loc, 0);
             this.instanced_arrays_ext.vertexAttribDivisorANGLE(this.a_lineThicknessAndLength_loc, 0);
@@ -414,7 +418,11 @@ class PenSkin extends Skin {
             gl.vertexAttribDivisor(this.a_lineThicknessAndLength_loc, 1);
             gl.vertexAttribDivisor(this.a_penPoints_loc, 1);
 
-            gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, this.attribute_index / PEN_ATTRIBUTE_STRIDE);
+            gl.drawArraysInstanced(
+                gl.TRIANGLES,
+                0, 6,
+                this.attribute_index / PEN_ATTRIBUTE_STRIDE
+            );
 
             gl.vertexAttribDivisor(this.a_lineColor_loc, 0);
             gl.vertexAttribDivisor(this.a_lineThicknessAndLength_loc, 0);

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -106,13 +106,14 @@ class PenSkin extends Skin {
             const instancedArraysExtension = gl.getExtension('ANGLE_instanced_arrays');
             if (instancedArraysExtension) {
                 this.instancedRendering = true;
-                this.glDrawArraysInstanced = instancedArraysExtension.drawElementsInstancedANGLE.bind(
+                this.glDrawArraysInstanced = instancedArraysExtension.drawArraysInstancedANGLE.bind(
                     instancedArraysExtension
                 );
                 this.glVertexAttribDivisor = instancedArraysExtension.vertexAttribDivisorANGLE.bind(
                     instancedArraysExtension
                 );
             } else {
+                // Inefficient but still supported
                 this.instancedRendering = false;
             }
         }
@@ -390,13 +391,13 @@ class PenSkin extends Skin {
             this.attribute_index++;
             this.attribute_data[this.attribute_index] = penColor[3];
             this.attribute_index++;
-    
+
             this.attribute_data[this.attribute_index] = lineThickness;
             this.attribute_index++;
-    
+
             this.attribute_data[this.attribute_index] = lineLength;
             this.attribute_index++;
-    
+
             this.attribute_data[this.attribute_index] = x0;
             this.attribute_index++;
             this.attribute_data[this.attribute_index] = -y0;
@@ -440,13 +441,13 @@ class PenSkin extends Skin {
             this.glVertexAttribDivisor(this.a_lineColor_loc, 1);
             this.glVertexAttribDivisor(this.a_lineThicknessAndLength_loc, 1);
             this.glVertexAttribDivisor(this.a_penPoints_loc, 1);
-    
+
             this.glDrawArraysInstanced(
                 gl.TRIANGLES,
                 0, 6,
                 this.attribute_index / PEN_ATTRIBUTE_STRIDE
             );
-    
+
             this.glVertexAttribDivisor(this.a_lineColor_loc, 0);
             this.glVertexAttribDivisor(this.a_lineThicknessAndLength_loc, 0);
             this.glVertexAttribDivisor(this.a_penPoints_loc, 0);

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -108,6 +108,11 @@ class PenSkin extends Skin {
         gl.bindBuffer(gl.ARRAY_BUFFER, this.attribute_buffer = gl.createBuffer());
         gl.bufferData(gl.ARRAY_BUFFER, this.attribute_data.length * 4, gl.STREAM_DRAW);
 
+        if (!gl.drawArraysInstanced) {
+            // Fallback to ANGLE_instanced_arrays
+            this.instanced_arrays_ext = gl.getExtension("ANGLE_instanced_arrays");
+        }
+
         this.onNativeSizeChanged = this.onNativeSizeChanged.bind(this);
         this._renderer.on(RenderConstants.Events.NativeSizeChanged, this.onNativeSizeChanged);
 
@@ -378,7 +383,6 @@ class PenSkin extends Skin {
             4, gl.FLOAT, false,
             PEN_ATTRIBUTE_STRIDE_BYTES, 0
         );
-        gl.vertexAttribDivisor(this.a_lineColor_loc, 1);
 
         gl.enableVertexAttribArray(this.a_lineThicknessAndLength_loc);
         gl.vertexAttribPointer(
@@ -386,7 +390,6 @@ class PenSkin extends Skin {
             2, gl.FLOAT, false,
             PEN_ATTRIBUTE_STRIDE_BYTES, 4 * 4
         );
-        gl.vertexAttribDivisor(this.a_lineThicknessAndLength_loc, 1);
 
         gl.enableVertexAttribArray(this.a_penPoints_loc);
         gl.vertexAttribPointer(
@@ -394,13 +397,29 @@ class PenSkin extends Skin {
             4, gl.FLOAT, false,
             PEN_ATTRIBUTE_STRIDE_BYTES, 6 * 4
         );
-        gl.vertexAttribDivisor(this.a_penPoints_loc, 1);
 
-        gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, this.attribute_index / PEN_ATTRIBUTE_STRIDE);
+        if (this.instanced_arrays_ext) {
+            // ANGLE_instanced_arrays fallback
+            this.instanced_arrays_ext.vertexAttribDivisorANGLE(this.a_lineColor_loc, 1);
+            this.instanced_arrays_ext.vertexAttribDivisorANGLE(this.a_lineThicknessAndLength_loc, 1);
+            this.instanced_arrays_ext.vertexAttribDivisorANGLE(this.a_penPoints_loc, 1);
 
-        gl.vertexAttribDivisor(this.a_lineColor_loc, 0);
-        gl.vertexAttribDivisor(this.a_lineThicknessAndLength_loc, 0);
-        gl.vertexAttribDivisor(this.a_penPoints_loc, 0);
+            this.instanced_arrays_ext.drawArraysInstancedANGLE(gl.TRIANGLES, 0, 6, this.attribute_index / PEN_ATTRIBUTE_STRIDE);
+
+            this.instanced_arrays_ext.vertexAttribDivisorANGLE(this.a_lineColor_loc, 0);
+            this.instanced_arrays_ext.vertexAttribDivisorANGLE(this.a_lineThicknessAndLength_loc, 0);
+            this.instanced_arrays_ext.vertexAttribDivisorANGLE(this.a_penPoints_loc, 0);
+        } else {
+            gl.vertexAttribDivisor(this.a_lineColor_loc, 1);
+            gl.vertexAttribDivisor(this.a_lineThicknessAndLength_loc, 1);
+            gl.vertexAttribDivisor(this.a_penPoints_loc, 1);
+
+            gl.drawArraysInstanced(gl.TRIANGLES, 0, 6, this.attribute_index / PEN_ATTRIBUTE_STRIDE);
+
+            gl.vertexAttribDivisor(this.a_lineColor_loc, 0);
+            gl.vertexAttribDivisor(this.a_lineThicknessAndLength_loc, 0);
+            gl.vertexAttribDivisor(this.a_penPoints_loc, 0);
+        }
 
         this._resetAttributeIndex();
 

--- a/src/PenSkin.js
+++ b/src/PenSkin.js
@@ -90,11 +90,15 @@ class PenSkin extends Skin {
         this.a_position_glbuffer = gl.createBuffer();
         this.a_position_loc = gl.getAttribLocation(this._lineShader.program, 'a_position');
 
-        this.attribute_glbuffer = gl.createBuffer();
-        this.attribute_index = 0;
         this.a_lineColor_loc = gl.getAttribLocation(this._lineShader.program, 'a_lineColor');
         this.a_lineThicknessAndLength_loc = gl.getAttribLocation(this._lineShader.program, 'a_lineThicknessAndLength');
         this.a_penPoints_loc = gl.getAttribLocation(this._lineShader.program, 'a_penPoints');
+
+        this.attribute_glbuffer = gl.createBuffer();
+        this.attribute_index = 0;
+        this.attribute_data = new Float32Array(PEN_ATTRIBUTE_BUFFER_SIZE);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.attribute_glbuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, this.attribute_data.length * 4, gl.STREAM_DRAW);
 
         if (gl.drawArraysInstanced) {
             // WebGL2 has native instanced rendering
@@ -128,10 +132,6 @@ class PenSkin extends Skin {
                 0, 0,
                 0, 1
             ]), gl.STATIC_DRAW);
-
-            this.attribute_data = new Float32Array(PEN_ATTRIBUTE_BUFFER_SIZE);
-            gl.bindBuffer(gl.ARRAY_BUFFER, this.attribute_glbuffer);
-            gl.bufferData(gl.ARRAY_BUFFER, this.attribute_data.length * 4, gl.STREAM_DRAW);
         } else {
             const positionBuffer = new Float32Array(PEN_ATTRIBUTE_BUFFER_SIZE / PEN_ATTRIBUTE_STRIDE * 2);
             for (let i = 0; i < positionBuffer.length; i += 12) {
@@ -150,10 +150,6 @@ class PenSkin extends Skin {
             }
             gl.bindBuffer(gl.ARRAY_BUFFER, this.a_position_glbuffer);
             gl.bufferData(gl.ARRAY_BUFFER, positionBuffer, gl.STATIC_DRAW);
-
-            this.attribute_data = new Float32Array(PEN_ATTRIBUTE_BUFFER_SIZE);
-            gl.bindBuffer(gl.ARRAY_BUFFER, this.attribute_glbuffer);
-            gl.bufferData(gl.ARRAY_BUFFER, this.attribute_data.length * 4, gl.STREAM_DRAW);
         }
 
         this.onNativeSizeChanged = this.onNativeSizeChanged.bind(this);

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -177,7 +177,7 @@ class RenderWebGL extends EventEmitter {
             throw new Error('Could not get WebGL context: this browser or environment may not support WebGL.');
         }
 
-        if (!gl.drawArraysInstanced) {
+        if (!gl.getExtension("ANGLE_instanced_arrays") && !gl.drawArraysInstanced) {
             throw new Error('Instanced rendering not supported.');
         }
 

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -172,8 +172,13 @@ class RenderWebGL extends EventEmitter {
 
         /** @type {WebGLRenderingContext} */
         const gl = this._gl = RenderWebGL._getContext(canvas);
+
         if (!gl) {
             throw new Error('Could not get WebGL context: this browser or environment may not support WebGL.');
+        }
+
+        if (!gl.drawArraysInstanced) {
+            throw new Error('Instanced rendering not supported.');
         }
 
         /** @type {RenderWebGL.UseGpuModes} */

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -177,7 +177,7 @@ class RenderWebGL extends EventEmitter {
             throw new Error('Could not get WebGL context: this browser or environment may not support WebGL.');
         }
 
-        if (!gl.getExtension("ANGLE_instanced_arrays") && !gl.drawArraysInstanced) {
+        if (!gl.getExtension('ANGLE_instanced_arrays') && !gl.drawArraysInstanced) {
             throw new Error('Instanced rendering not supported.');
         }
 

--- a/src/RenderWebGL.js
+++ b/src/RenderWebGL.js
@@ -172,13 +172,8 @@ class RenderWebGL extends EventEmitter {
 
         /** @type {WebGLRenderingContext} */
         const gl = this._gl = RenderWebGL._getContext(canvas);
-
         if (!gl) {
             throw new Error('Could not get WebGL context: this browser or environment may not support WebGL.');
-        }
-
-        if (!gl.getExtension('ANGLE_instanced_arrays') && !gl.drawArraysInstanced) {
-            throw new Error('Instanced rendering not supported.');
         }
 
         /** @type {RenderWebGL.UseGpuModes} */


### PR DESCRIPTION
This is an optimization for the pen line drawing which results in an increase in performance in some projects, particularly raycasters or other 3D projects which draw a lot of lines. For me, this results in a bigger performance boost in firefox then chrome, but is very measurable in both.

The main difference is instead of writing the attributes for each pen line 6 times (once for each vertex), I am using instance rendering to only need to write the data once. This also allows all pen lines to share the same short vertex position buffer instead of having to have identical data copied a lot of times.

I have also merged all attributes (other than position) into one buffer, which allows the data to be written faster by the CPU and read faster by the GPU. It also saved on opengl calls.

The tests for this don't pass on my computer and the output is fairly incomprehensible, I suspect it's something about my environment given tests seemingly unrelated to what I've changed are failing.

I'm not sure how to test this more rigorously, definitely need to do more before merging, but I'm happy with the state the code is in.