### PR TITLE
Optimize silhouette readback canvas

### DIFF
--- a/src/Silhouette.js
+++ b/src/Silhouette.js
@@ -175,7 +175,7 @@ class Silhouette {
             const canvas = Silhouette._updateCanvas();
             canvas.width = width;
             canvas.height = height;
-            const ctx = canvas.getContext('2d');
+            const ctx = canvas.getContext('2d', {willReadFrequently: true});
 
             ctx.clearRect(0, 0, width, height);
             ctx.drawImage(this._lazyData, 0, 0, width, height);

--- a/src/TextBubbleSkin.js
+++ b/src/TextBubbleSkin.js
@@ -69,9 +69,7 @@ class TextBubbleSkin extends Skin {
          */
         this._style = DEFAULT_BUBBLE_STYLE;
 
-        this.measurementProvider = new CanvasMeasurementProvider(
-            this._canvas.getContext('2d', {willReadFrequently: true})
-        );
+        this.measurementProvider = new CanvasMeasurementProvider(this._canvas.getContext('2d'));
         this.textWrapper = renderer.createTextWrapper(this.measurementProvider);
 
         this._restyleCanvas();

--- a/src/TextBubbleSkin.js
+++ b/src/TextBubbleSkin.js
@@ -69,7 +69,9 @@ class TextBubbleSkin extends Skin {
          */
         this._style = DEFAULT_BUBBLE_STYLE;
 
-        this.measurementProvider = new CanvasMeasurementProvider(this._canvas.getContext('2d'));
+        this.measurementProvider = new CanvasMeasurementProvider(
+            this._canvas.getContext('2d', {willReadFrequently: true})
+        );
         this.textWrapper = renderer.createTextWrapper(this.measurementProvider);
 
         this._restyleCanvas();


### PR DESCRIPTION
Use a readback-optimized Canvas2D context for the shared canvas used by `Silhouette.unlazy()` during SVG/bitmap picking.

Passing `willReadFrequently: true` at the canvas's initial context creation declares the repeated `getImageData()` usage up front and avoids Chromium's Canvas2D readback heuristic warning. Other renderer canvases, including `TextBubbleSkin`, are unchanged.

Microbenchmark (Chrome 149.0.7827.55 headless on macOS; shared 480×360 canvas; resize → drawImage → getImageData; median of 10 alternating rounds):
- default context: 26.6 ms / 100 iterations
- `willReadFrequently: true`: 26.6 ms / 100 iterations

This benchmark does not show a measurable speed improvement, so the PR does not claim one.

Validation:
- `npm run lint`: pass
- `npm run build`: pass
- unit tests: pass
- GitHub CI: pass
- local legacy Playwright integration binary: cannot launch on this macOS/Node environment (`spawn Unknown system error -88`)

Downstream tracking: https://github.com/kubohiroya/tmpose-kamishibai/issues/564
